### PR TITLE
switch old log deletion back to 30 days

### DIFF
--- a/Grimoire.Core/Features/Logging/Queries/GetOldLogMessages/GetOldLogMessagesQueryHandler.cs
+++ b/Grimoire.Core/Features/Logging/Queries/GetOldLogMessages/GetOldLogMessagesQueryHandler.cs
@@ -18,7 +18,7 @@ public class GetOldLogMessagesQueryHandler : IRequestHandler<GetOldLogMessagesQu
 
     public async ValueTask<IEnumerable<GetOldLogMessagesQueryResponse>> Handle(GetOldLogMessagesQuery request, CancellationToken cancellationToken)
     {
-        var oldDate = DateTime.UtcNow - TimeSpan.FromMinutes(1);
+        var oldDate = DateTime.UtcNow - TimeSpan.FromDays(30);
         return await this._grimoireDbContext.OldLogMessages
             .Where(x => x.CreatedAt < oldDate)
             .GroupBy(x => new { x.ChannelId, x.GuildId })


### PR DESCRIPTION
Forgot to switch the time when old logs should be deleted to 30 days.