### PR TITLE
Upgrading the nefarius plugin versions that removed opentracing. Hopi…

### DIFF
--- a/Grimoire.Discord/Grimoire.Discord.csproj
+++ b/Grimoire.Discord/Grimoire.Discord.csproj
@@ -25,9 +25,9 @@
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.8" />
     <PackageReference Include="Microsoft.NET.Build.Containers" Version="7.0.305" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />
-    <PackageReference Include="Nefarius.DSharpPlus.CommandsNext.Extensions.Hosting" Version="4.4.710" />
-    <PackageReference Include="Nefarius.DSharpPlus.Interactivity.Extensions.Hosting" Version="4.4.710" />
-    <PackageReference Include="Nefarius.DSharpPlus.SlashCommands.Extensions.Hosting" Version="4.4.710" />
+    <PackageReference Include="Nefarius.DSharpPlus.CommandsNext.Extensions.Hosting" Version="4.4.718" />
+    <PackageReference Include="Nefarius.DSharpPlus.Interactivity.Extensions.Hosting" Version="4.4.718" />
+    <PackageReference Include="Nefarius.DSharpPlus.SlashCommands.Extensions.Hosting" Version="4.4.718" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" />


### PR DESCRIPTION
…ng that fixes the memory leak